### PR TITLE
Feat/front/classroom

### DIFF
--- a/Backend/edututor/src/main/java/com/tls/edututor/classroom/entity/Classroom.java
+++ b/Backend/edututor/src/main/java/com/tls/edututor/classroom/entity/Classroom.java
@@ -2,6 +2,7 @@ package com.tls.edututor.classroom.entity;
 
 import com.tls.edututor.classroom.dto.request.ClassroomRequest;
 import com.tls.edututor.common.entity.BaseEntity;
+import com.tls.edututor.school.entity.School;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -18,6 +19,10 @@ public class Classroom extends BaseEntity {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "SCHOOL_ID", nullable = false)
+  private School school;
+
   @Column(name = "CLASSROOM_NAME", nullable = false)
   private String classroomName;
 
@@ -28,7 +33,8 @@ public class Classroom extends BaseEntity {
   private String grade;
 
   @Builder(builderMethodName = "withDto")
-  public Classroom(ClassroomRequest request, String type) {
+  public Classroom(ClassroomRequest request, School school, String type) {
+    this.school = school;
     classroomName = request.getClassroomName();
     year = request.getYear();
     grade = request.getGrade();

--- a/Backend/edututor/src/main/java/com/tls/edututor/code/codedetail/repository/CodeDetailRepository.java
+++ b/Backend/edututor/src/main/java/com/tls/edututor/code/codedetail/repository/CodeDetailRepository.java
@@ -11,19 +11,7 @@ import java.util.Optional;
 public interface CodeDetailRepository extends JpaRepository<CodeDetail, Long> {
 
   @Query("SELECT cd FROM CodeDetail cd WHERE cd.codeGroup.id = :codeGroupId AND cd.id = :codeId")
-  Optional<CodeDetail> findSubjectById(@Param("codeGroupId") String codeGroupId, @Param("codeId") String codeId);
-
-  @Query("SELECT cd FROM CodeDetail cd WHERE cd.codeGroup.id = :codeGroupId AND cd.id = :codeId")
-  Optional<CodeDetail> findSemesterById(@Param("codeGroupId") String codeGroupId, @Param("codeId") String codeId);
-
-  @Query("SELECT cd FROM CodeDetail cd WHERE cd.codeGroup.id = :codeGroupId AND cd.id = :codeId")
-  Optional<CodeDetail> findGradeById(@Param("codeGroupId") String codeGroupId, @Param("codeId") String codeId);
-
-  @Query("SELECT cd FROM CodeDetail cd WHERE cd.codeGroup.id = :codeGroupId AND cd.id = :codeId")
-  Optional<CodeDetail> findSchoolLevelsById(@Param("codeGroupId") String codeGroupId, @Param("codeId") String codeId);
-
-  @Query("SELECT cd FROM CodeDetail cd WHERE cd.codeGroup.id = :codeGroupId AND cd.id = :codeId")
-  Optional<CodeDetail> findRoleById(@Param("codeGroupId") String codeGroupId, @Param("codeId") String codeId);
+  Optional<CodeDetail> findById(String codeId);
 
   List<CodeDetail> findByCodeGroupId(String groupId);
 

--- a/Backend/edututor/src/main/java/com/tls/edututor/school/entity/School.java
+++ b/Backend/edututor/src/main/java/com/tls/edututor/school/entity/School.java
@@ -1,5 +1,6 @@
 package com.tls.edututor.school.entity;
 
+import com.tls.edututor.common.entity.BaseEntity;
 import com.tls.edututor.school.dto.request.SchoolRequest;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -10,7 +11,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class School {
+public class School extends BaseEntity {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/Backend/edututor/src/main/java/com/tls/edututor/user/controller/UserController.java
+++ b/Backend/edututor/src/main/java/com/tls/edututor/user/controller/UserController.java
@@ -1,6 +1,7 @@
 package com.tls.edututor.user.controller;
 
 import com.tls.edututor.common.api.CommonApiResponse;
+import com.tls.edututor.user.dto.request.UserSURequest;
 import com.tls.edututor.user.dto.request.UserTERequest;
 import com.tls.edututor.user.service.UserService;
 import lombok.RequiredArgsConstructor;
@@ -15,17 +16,23 @@ public class UserController {
   private final UserService userService;
 
   @GetMapping("/users/{loginId}")
-  public CommonApiResponse<?> checkloginId(@PathVariable("loginId") String loginId) {
+  public CommonApiResponse<?> checkLoginId(@PathVariable("loginId") String loginId) {
     boolean isAvailable = userService.checkJoinAvailable(loginId);
     if (isAvailable) return CommonApiResponse.createBadRequest("");
     else return CommonApiResponse.createNoContent("");
   }
 
 
-  @PostMapping("/users")
-  public CommonApiResponse<?> join(@RequestBody UserTERequest request) {
-    userService.saveUser(request);
+  @PostMapping("/users/teachers")
+  public CommonApiResponse<?> teacherJoin(@RequestBody UserTERequest request) {
+    userService.saveTeacher(request);
     return CommonApiResponse.createNoContent("회원가입이 완료되었습니다.");
+  }
+
+  @PostMapping("/users/students")
+  public CommonApiResponse<?> createStudent(@RequestBody UserSURequest request) {
+    userService.saveStudent(request);
+    return CommonApiResponse.createNoContent("학생 등록이 완료되었습니다.");
   }
 
 }

--- a/Backend/edututor/src/main/java/com/tls/edututor/user/dto/request/UserSURequest.java
+++ b/Backend/edututor/src/main/java/com/tls/edututor/user/dto/request/UserSURequest.java
@@ -1,0 +1,20 @@
+package com.tls.edututor.user.dto.request;
+
+import com.tls.edututor.classroom.entity.Classroom;
+import com.tls.edututor.school.entity.School;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
+public class UserSURequest {
+  private Long teacherId;
+  private String fullName;
+  private String loginId;
+  private String password;
+  private School school;
+  private Classroom classroom;
+  private String type;
+}

--- a/Backend/edututor/src/main/java/com/tls/edututor/user/dto/request/UserTERequest.java
+++ b/Backend/edututor/src/main/java/com/tls/edututor/user/dto/request/UserTERequest.java
@@ -24,4 +24,6 @@ public class UserTERequest {
 
   private SchoolRequest school;
   private ClassroomRequest classroom;
+
+  private String type;
 }

--- a/Backend/edututor/src/main/java/com/tls/edututor/user/dto/response/AuthUser.java
+++ b/Backend/edututor/src/main/java/com/tls/edututor/user/dto/response/AuthUser.java
@@ -1,5 +1,6 @@
 package com.tls.edututor.user.dto.response;
 
+import com.tls.edututor.classroom.entity.Classroom;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.ToString;
@@ -8,9 +9,9 @@ import lombok.ToString;
 @AllArgsConstructor
 @ToString
 public class AuthUser {
-
   private Long id;
   private String fullName;
   private String email;
+  private Classroom classroom;
   private String role;
 }

--- a/Backend/edututor/src/main/java/com/tls/edututor/user/dto/response/CustomUser.java
+++ b/Backend/edututor/src/main/java/com/tls/edututor/user/dto/response/CustomUser.java
@@ -1,5 +1,6 @@
 package com.tls.edututor.user.dto.response;
 
+import com.tls.edututor.classroom.entity.Classroom;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -66,5 +67,9 @@ public class CustomUser implements UserDetails {
 
   public String getFullName() {
     return user.getFullName();
+  }
+
+  public Classroom getClassroom() {
+    return user.getClassroom();
   }
 }

--- a/Backend/edututor/src/main/java/com/tls/edututor/user/entity/User.java
+++ b/Backend/edututor/src/main/java/com/tls/edututor/user/entity/User.java
@@ -2,6 +2,7 @@ package com.tls.edututor.user.entity;
 
 import com.tls.edututor.classroom.entity.Classroom;
 import com.tls.edututor.common.entity.BaseEntity;
+import com.tls.edututor.user.dto.request.UserSURequest;
 import com.tls.edututor.user.dto.request.UserTERequest;
 import jakarta.persistence.*;
 import lombok.*;
@@ -17,7 +18,8 @@ public class User extends BaseEntity {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  @ManyToOne
+  // 학생들도 같은 classroom을 참조할 수 있도록
+  @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
   @JoinColumn(name = "CLASS_ID")
   private Classroom classroom;
 
@@ -30,24 +32,40 @@ public class User extends BaseEntity {
   @Column(name = "FULL_NAME", nullable = false)
   private String fullName;
 
-  @Column(name = "EMAIL", nullable = false)
+  @Column(name = "EMAIL")
   private String email;
 
-  @Column(name = "PHONE_NUM", nullable = false)
+  @Column(name = "PHONE_NUM")
   private String phoneNum;
 
-  @Column(name = "BIRTH", nullable = false)
+  @Column(name = "BIRTH")
   private LocalDate birthDay;
 
-  @Builder(builderMethodName = "withDto")
-  public User(UserTERequest dto, Classroom classroom) {
-    this.classroom = classroom;
-    loginId = dto.getLoginId();
-    password = dto.getPassword();
-    fullName = dto.getFullName();
-    email = dto.getEmail();
-    phoneNum = dto.getPhoneNum();
-    birthDay = dto.getBirthDay();
+  @Column(name = "role", nullable = false)
+  private String role;
+
+  public static User createTeacher(UserTERequest dto) {
+    User user = new User();
+    user.loginId = dto.getLoginId();
+    user.password = dto.getPassword();
+    user.fullName = dto.getFullName();
+    user.email = dto.getEmail();
+    user.phoneNum = dto.getPhoneNum();
+    user.birthDay = dto.getBirthDay();
+    user.role = dto.getType();
+    return user;
   }
 
+  public static User createStudent(UserSURequest dto) {
+    User user = new User();
+    user.loginId = dto.getLoginId();
+    user.password = dto.getPassword();
+    user.fullName = dto.getFullName();
+    user.role = dto.getType();
+    return user;
+  }
+
+  public void setClassroom(Classroom classroom) {
+    this.classroom = classroom;
+  }
 }

--- a/Backend/edututor/src/main/java/com/tls/edututor/user/jwt/JwtFilter.java
+++ b/Backend/edututor/src/main/java/com/tls/edututor/user/jwt/JwtFilter.java
@@ -40,7 +40,7 @@ public class JwtFilter extends OncePerRequestFilter {
         if (cookie.getName().startsWith("access"))
           accessToken = cookie.getValue();
       }
-      
+
       if (accessToken.isBlank()) {
         filterChain.doFilter(request, response);
         return;
@@ -73,7 +73,7 @@ public class JwtFilter extends OncePerRequestFilter {
 
     SimpleGrantedAuthority authority = new SimpleGrantedAuthority(roles);
 
-    AuthUser authUser = new AuthUser(userId, username, email, authority.getAuthority());
+    AuthUser authUser = new AuthUser(userId, username, email, null, authority.getAuthority());
 
     UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(authUser, null, List.of(authority));
 

--- a/Backend/edututor/src/main/java/com/tls/edututor/user/jwt/JwtFilter.java
+++ b/Backend/edututor/src/main/java/com/tls/edututor/user/jwt/JwtFilter.java
@@ -34,10 +34,16 @@ public class JwtFilter extends OncePerRequestFilter {
       return;
     }
 
+
     try {
       for (Cookie cookie : cookies) {
         if (cookie.getName().startsWith("access"))
           accessToken = cookie.getValue();
+      }
+      
+      if (accessToken.isBlank()) {
+        filterChain.doFilter(request, response);
+        return;
       }
 
       jwtUtil.isExpired(accessToken);

--- a/Backend/edututor/src/main/java/com/tls/edututor/user/repository/UserRepository.java
+++ b/Backend/edututor/src/main/java/com/tls/edututor/user/repository/UserRepository.java
@@ -1,11 +1,15 @@
 package com.tls.edututor.user.repository;
 
 import com.tls.edututor.user.entity.User;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
+
+  @EntityGraph(attributePaths = {"classroom", "classroom.school"})
   Optional<User> findByLoginId(String loginId);
 
   boolean existsByLoginId(String loginId);

--- a/Backend/edututor/src/main/java/com/tls/edututor/user/service/CustomUserDetailsService.java
+++ b/Backend/edututor/src/main/java/com/tls/edututor/user/service/CustomUserDetailsService.java
@@ -23,22 +23,25 @@ public class CustomUserDetailsService implements UserDetailsService {
   public UserDetails loadUserByUsername(String loginId) throws UsernameNotFoundException {
     User user = userRepository.findByLoginId(loginId).orElseThrow(() -> new BadCredentialsException("AUTH001"));
 
-    String role = determineUserRole(user);
+    String role = determineUserRole(user.getRole());
 
     AuthUser authUser = new AuthUser(user.getId(), user.getFullName(), user.getEmail(), role);
 
     return new CustomUser(authUser, user.getLoginId(), user.getPassword());
   }
 
-  private String determineUserRole(User user) {
-    if (user.getPhoneNum() != null && user.getBirthDay() != null) {
-      return codeDetailRepository.findRoleById("1005", "TE")
+  private String determineUserRole(String type) {
+    String role = type;
+    if (role.startsWith("TE")) {
+      role = codeDetailRepository.findRoleById("1005", "TE")
               .orElseThrow(() -> new RuntimeException("Role TE not found"))
               .getId();
-    } else {
-      return codeDetailRepository.findRoleById("1005", "SU")
+    } else if (role.startsWith("SU")) {
+      role = codeDetailRepository.findRoleById("1005", "SU")
               .orElseThrow(() -> new RuntimeException("Role SU not found"))
               .getId();
     }
+
+    return role;
   }
 }

--- a/Backend/edututor/src/main/java/com/tls/edututor/user/service/CustomUserDetailsService.java
+++ b/Backend/edututor/src/main/java/com/tls/edututor/user/service/CustomUserDetailsService.java
@@ -19,31 +19,13 @@ import org.springframework.transaction.annotation.Transactional;
 public class CustomUserDetailsService implements UserDetailsService {
 
   private final UserRepository userRepository;
-  private final CodeDetailRepository codeDetailRepository;
 
   @Override
   public UserDetails loadUserByUsername(String loginId) throws UsernameNotFoundException {
     User user = userRepository.findByLoginId(loginId).orElseThrow(() -> new BadCredentialsException("AUTH001"));
 
-    String role = determineUserRole(user.getRole());
-
-    AuthUser authUser = new AuthUser(user.getId(), user.getFullName(), user.getEmail(), user.getClassroom(), role);
+    AuthUser authUser = new AuthUser(user.getId(), user.getFullName(), user.getEmail(), user.getClassroom(), user.getRole());
 
     return new CustomUser(authUser, user.getLoginId(), user.getPassword());
-  }
-
-  private String determineUserRole(String type) {
-    String role = type;
-    if (role.startsWith("TE")) {
-      role = codeDetailRepository.findRoleById("1005", "TE")
-              .orElseThrow(() -> new RuntimeException("Role TE not found"))
-              .getId();
-    } else if (role.startsWith("SU")) {
-      role = codeDetailRepository.findRoleById("1005", "SU")
-              .orElseThrow(() -> new RuntimeException("Role SU not found"))
-              .getId();
-    }
-
-    return role;
   }
 }

--- a/Backend/edututor/src/main/java/com/tls/edututor/user/service/CustomUserDetailsService.java
+++ b/Backend/edututor/src/main/java/com/tls/edututor/user/service/CustomUserDetailsService.java
@@ -11,9 +11,11 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class CustomUserDetailsService implements UserDetailsService {
 
   private final UserRepository userRepository;
@@ -25,7 +27,7 @@ public class CustomUserDetailsService implements UserDetailsService {
 
     String role = determineUserRole(user.getRole());
 
-    AuthUser authUser = new AuthUser(user.getId(), user.getFullName(), user.getEmail(), role);
+    AuthUser authUser = new AuthUser(user.getId(), user.getFullName(), user.getEmail(), user.getClassroom(), role);
 
     return new CustomUser(authUser, user.getLoginId(), user.getPassword());
   }

--- a/Backend/edututor/src/main/java/com/tls/edututor/user/service/UserService.java
+++ b/Backend/edututor/src/main/java/com/tls/edututor/user/service/UserService.java
@@ -1,11 +1,14 @@
 package com.tls.edututor.user.service;
 
+import com.tls.edututor.user.dto.request.UserSURequest;
 import com.tls.edututor.user.dto.request.UserTERequest;
 
 public interface UserService {
 
   boolean checkJoinAvailable(String loginId);
 
-  Long saveUser(UserTERequest request);
+  Long saveTeacher(UserTERequest request);
+
+  Long saveStudent(UserSURequest request);
 
 }

--- a/Backend/edututor/src/main/java/com/tls/edututor/user/service/UserServiceImpl.java
+++ b/Backend/edututor/src/main/java/com/tls/edututor/user/service/UserServiceImpl.java
@@ -5,6 +5,7 @@ import com.tls.edututor.classroom.repository.ClassroomRepository;
 import com.tls.edututor.common.exception.DuplicateUserException;
 import com.tls.edututor.school.entity.School;
 import com.tls.edututor.school.repository.SchoolRepository;
+import com.tls.edututor.user.dto.request.UserSURequest;
 import com.tls.edututor.user.dto.request.UserTERequest;
 import com.tls.edututor.user.entity.User;
 import com.tls.edututor.user.repository.UserRepository;
@@ -28,31 +29,50 @@ public class UserServiceImpl implements UserService {
   }
 
   @Transactional
-  public Long saveUser(UserTERequest request) {
+  @Override
+  public Long saveTeacher(UserTERequest request) {
     if (userRepository.existsByLoginId(request.getLoginId())) {
       throw new DuplicateUserException(String.format("이미 {}로 회원가입이 되어있습니다.", request.getLoginId()));
     }
 
     request.setPassword(passwordEncoder.encode(request.getPassword()));
 
+    User user = User.createTeacher(request);
+    userRepository.save(user).getId();
+
     School school = School.withDto()
             .request(request.getSchool())
             .build();
+    school.setWriter(user.getId());
+    schoolRepository.save(school);
 
     Classroom classroom = Classroom.withDto()
             .request(request.getClassroom())
+            .school(school)
             .type(school.getType())
             .build();
-
-    User user = User.withDto()
-            .dto(request)
-            .classroom(classroom)
-            .build();
-
-    schoolRepository.save(school);
+    classroom.setWriter(user.getId());
     classroomRepository.save(classroom);
 
-    return userRepository.save(user).getId();
+    user.setClassroom(classroom);
+    user.setWriter(user.getId());
+
+    return user.getId();
   }
 
+  @Transactional
+  @Override
+  public Long saveStudent(UserSURequest request) {
+    if (userRepository.existsByLoginId(request.getLoginId())) {
+      throw new DuplicateUserException(String.format("이미 {}로 회원가입이 되어있습니다.", request.getLoginId()));
+    }
+    request.setPassword(passwordEncoder.encode(request.getPassword()));
+
+    User user = User.createStudent(request);
+    user.setWriter(request.getTeacherId());
+
+    userRepository.save(user);
+
+    return user.getId();
+  }
 }

--- a/Backend/edututor/src/main/java/com/tls/edututor/user/service/UserServiceImpl.java
+++ b/Backend/edututor/src/main/java/com/tls/edututor/user/service/UserServiceImpl.java
@@ -32,7 +32,7 @@ public class UserServiceImpl implements UserService {
   @Override
   public Long saveTeacher(UserTERequest request) {
     if (userRepository.existsByLoginId(request.getLoginId())) {
-      throw new DuplicateUserException(String.format("이미 {}로 회원가입이 되어있습니다.", request.getLoginId()));
+      throw new DuplicateUserException(String.format("이미 %s로 회원가입이 되어있습니다.", request.getLoginId()));
     }
 
     request.setPassword(passwordEncoder.encode(request.getPassword()));
@@ -64,7 +64,7 @@ public class UserServiceImpl implements UserService {
   @Override
   public Long saveStudent(UserSURequest request) {
     if (userRepository.existsByLoginId(request.getLoginId())) {
-      throw new DuplicateUserException(String.format("이미 {}로 회원가입이 되어있습니다.", request.getLoginId()));
+      throw new DuplicateUserException(String.format("이미 %s로 회원가입이 되어있습니다.", request.getLoginId()));
     }
     request.setPassword(passwordEncoder.encode(request.getPassword()));
 

--- a/Frontend/edututor/src/App.jsx
+++ b/Frontend/edututor/src/App.jsx
@@ -31,6 +31,7 @@ const UserJoin = lazy(() => import('./pages/user/UserJoin.jsx'));
 const UserLogin = lazy(() => import('./pages/user/UserLogin.jsx'));
 const TeacherLogin = lazy(() => import('./pages/user/TeacherLogin.jsx'));
 const StudentLogin = lazy(() => import('./pages/user/StudentLogin.jsx'));
+const Classroom = lazy(() => import('./pages/classroom/Classroom.jsx'));
 
 const LoadingSpinner = () => <Loading />;
 
@@ -91,6 +92,13 @@ function App() {
           <Route path="cmmn" element={
             <Suspense fallback={<LoadingSpinner />}><Board /></Suspense>
           } />
+
+          {/* class room */}
+          <Route path="classroom">
+            <Route index element={
+              <Suspense fallback={<LoadingSpinner />}><Classroom /></Suspense>
+            } />
+          </Route>
         </Route>
 
         <Route path="/login" element={

--- a/Frontend/edututor/src/api/user/user.js
+++ b/Frontend/edututor/src/api/user/user.js
@@ -12,8 +12,13 @@ export const checkDuplicateId = async (loginId) => {
   return response.data;
 };
 
-export const join = async (data) => {
-  const response = await axios.post(`${BASE_URL}/users`, data);
+export const teacherJoin = async (data) => {
+  const response = await axios.post(`${BASE_URL}/users/teachers`, data);
+  return response.data;
+};
+
+export const createStudent = async (data) => {
+  const response = await axios.post(`${BASE_URL}/users/students`, data);
   return response.data;
 };
 

--- a/Frontend/edututor/src/api/user/user.js
+++ b/Frontend/edututor/src/api/user/user.js
@@ -1,7 +1,6 @@
 import axios from 'axios';
 
 const BASE_URL = import.meta.env.VITE_BASE_URL;
-axios.defaults.withCredentials = true;
 
 /**
  * 회원가입 아이디 중복체크
@@ -19,6 +18,8 @@ export const join = async (data) => {
 };
 
 export const login = async (data) => {
-  const response = await axios.post(`${BASE_URL}/login`, data);
+  const response = await axios.post(`${BASE_URL}/login`, data, {
+    withCredentials: true
+  });
   return response.data;
 };

--- a/Frontend/edututor/src/components/classroom/CreateStudent.jsx
+++ b/Frontend/edututor/src/components/classroom/CreateStudent.jsx
@@ -1,4 +1,7 @@
 import styled from 'styled-components';
+import CreateStudentModal from './CreateStudentModal.jsx';
+import { useState } from 'react';
+import { checkDuplicateId } from '../../api/user/user.js';
 
 const CreateButton = styled.button`
     padding: 0.5rem 1rem;
@@ -7,18 +10,153 @@ const CreateButton = styled.button`
     color: #6B21A8;
     border: none;
     cursor: pointer;
-    transition: all 0.2s;
+    transition: all 0.5s;
 
     &:hover {
         background-color: #E9D5FF;
     }
 `;
 
+const initForm = {
+  name         : '',
+  loginId      : '',
+  password     : '',
+  passwordCheck: '',
+  grade        : '',
+  classNumber  : ''
+};
+
+
 const CreateStudent = () => {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [form, setForm] = useState(initForm);
+  const [errors, setErrors] = useState({});
+  const [isIdChecked, setIsIdChecked] = useState(false);
+  const [idCheckMessage, setIdCheckMessage] = useState('');
+
+  const handleInputChange = (e) => {
+    const { name, value } = e.target;
+    setForm(prev => ({
+      ...prev,
+      [name]: value
+    }));
+
+    if (name === 'loginId') {
+      setIsIdChecked(false);
+      setIdCheckMessage('');
+    }
+
+    validateInput(name, value);
+  };
+
+  const validateInput = (name, value) => {
+    switch (name) {
+      case 'name':
+        setErrors(prev => ({
+          ...prev,
+          name: !value ? '이름을 입력해주세요' : ''  // 에러 메시지를 문자열로 설정
+        }));
+        break;
+
+      case 'loginId':
+        if (value) {
+          const loginIdRegex = /^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]{6,20}$/;
+          setErrors(prev => ({
+            ...prev,
+            loginId: !loginIdRegex.test(value) ? '영문 대/소문자 + 숫자조합 (6~20자 이내)' : ''
+          }));
+        }
+        break;
+
+      case 'password':
+        if (value) {
+          const passwordRegex = /^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*#?&])[A-Za-z\d@$!%*#?&]{9,20}$/;
+          setErrors(prev => ({
+            ...prev,
+            password: !passwordRegex.test(value) ?
+              '영문 대/소문자, 숫자, 특수문자를 모두 포함하여 9-20자로 입력해주세요.' : ''
+          }));
+        }
+        break;
+
+      case 'passwordCheck':
+        setErrors(prev => ({
+          ...prev,
+          passwordMatch: form.password !== value ? '비밀번호가 일치하지 않습니다.' : ''
+        }));
+        break;
+
+      case 'classNumber':
+        setErrors(prev => ({
+          ...prev,
+          classNumber: !value ? '반 이름을 입력해주세요' : ''
+        }));
+        break;
+
+      case 'grade':
+        setErrors(prev => ({
+          ...prev,
+          grade: !value ? '학년을 선택해주세요' : ''
+        }));
+        break;
+    }
+  };
+
+  const handleCheckDuplicatedId = async () => {
+    if (!form.loginId) {
+      alert('아이디를 입력해주세요.');
+      return;
+    }
+
+    if (form.loginId.length < 6) {
+      alert('아이디가 너무 짧습니다.');
+      return;
+    }
+
+    if (form.loginId.length > 20) {
+      alert('아이디를 줄여주세요.');
+      return;
+    }
+
+    try {
+      const result = await checkDuplicateId(form.loginId);
+      if (result.status === 204) {
+        setIsIdChecked(true);
+        setIdCheckMessage('사용 가능한 아이디 입니다.');
+      } else {
+        setIsIdChecked(false);
+        setIdCheckMessage('이미 사용중이 아이디입니다.');
+      }
+
+    } catch (error) {
+      console.error('아이디 중복체크 실패: ', error);
+      setIsIdChecked(false);
+      setIdCheckMessage('중복 확인 중 오류가 발생하였습니다.');
+    }
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    // ... 제출 로직
+  };
+
   return (
-    <CreateButton>
-      + 학생 계정 생성
-    </CreateButton>
+    <>
+      <CreateButton onClick={() => setIsModalOpen(true)}>
+        + 학생 계정 생성
+      </CreateButton>
+      <CreateStudentModal
+        isOpen={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+        form={form}
+        errors={errors}
+        isIdChecked={isIdChecked}
+        idCheckMessage={idCheckMessage}
+        handleInputChange={handleInputChange}
+        handleCheckDuplicatedId={handleCheckDuplicatedId}
+        handleSubmit={handleSubmit}
+      />
+    </>
   );
 };
 

--- a/Frontend/edututor/src/components/classroom/CreateStudent.jsx
+++ b/Frontend/edututor/src/components/classroom/CreateStudent.jsx
@@ -1,0 +1,25 @@
+import styled from 'styled-components';
+
+const CreateButton = styled.button`
+    padding: 0.5rem 1rem;
+    border-radius: 9999px;
+    background-color: #F3E8FF;
+    color: #6B21A8;
+    border: none;
+    cursor: pointer;
+    transition: all 0.2s;
+
+    &:hover {
+        background-color: #E9D5FF;
+    }
+`;
+
+const CreateStudent = () => {
+  return (
+    <CreateButton>
+      + 학생 계정 생성
+    </CreateButton>
+  );
+};
+
+export default CreateStudent;

--- a/Frontend/edututor/src/components/classroom/CreateStudentModal.jsx
+++ b/Frontend/edututor/src/components/classroom/CreateStudentModal.jsx
@@ -1,13 +1,17 @@
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import {
   Button,
-  ClassroomGroup,
-  ErrorText, FieldSet,
-  FormGroup, FormHeader,
-  Input, InputGroup,
+  ErrorText,
+  FieldSet,
+  FormGroup,
+  FormHeader,
+  Input,
+  InputGroup,
   Label,
   Required,
-  Select, SuccessText, Title
+  SubTitle,
+  SuccessText,
+  Title
 } from '../common/UserStyledComponents.js';
 import styled from 'styled-components';
 
@@ -53,7 +57,8 @@ const CreateStudentModal = ({
                               idCheckMessage,
                               handleInputChange,
                               handleCheckDuplicatedId,
-                              handleSubmit
+                              handleSubmit,
+                              classroomName
                             }) => {
 
   useEffect(() => {
@@ -84,8 +89,8 @@ const CreateStudentModal = ({
                   이름<Required>*</Required>
                 </Label>
                 <Input
-                  name="name"
-                  value={form.name}
+                  name="fullName"
+                  value={form.fullName}
                   onChange={handleInputChange}
                   placeholder="이름을 입력해주세요"
                   $hasError={!!errors.name}
@@ -148,34 +153,18 @@ const CreateStudentModal = ({
 
               <FormGroup>
                 <Label>
-                  반 정보<Required>*</Required>
+                  <SubTitle $isModal>{classroomName} 반 정보<Required>*</Required></SubTitle>
                 </Label>
-                <ClassroomGroup>
-                  <Select
-                    name="grade"
-                    value={form.grade}
-                    onChange={handleInputChange}
-                    $hasError={!!errors.grade}
-                  >
-                    <option value="">학년</option>
-                    <option value="1">1학년</option>
-                    <option value="2">2학년</option>
-                    <option value="3">3학년</option>
-                  </Select>
+                <InputGroup>
                   <Input
                     name="classNumber"
                     value={form.classNumber}
                     onChange={handleInputChange}
-                    placeholder="반 이름"
-                    maxLength={10}
+                    placeholder="몇반인지 입력해주세요."
                     $hasError={!!errors.classNumber}
                   />
-                </ClassroomGroup>
-                {(errors.grade || errors.classNumber) && (
-                  <ErrorText>
-                    {errors.grade || errors.classNumber}
-                  </ErrorText>
-                )}
+                </InputGroup>
+                {errors.classNumber && <ErrorText>{errors.classNumber}</ErrorText>}
               </FormGroup>
 
               <FormGroup>

--- a/Frontend/edututor/src/components/classroom/CreateStudentModal.jsx
+++ b/Frontend/edututor/src/components/classroom/CreateStudentModal.jsx
@@ -1,0 +1,197 @@
+import { useEffect, useState } from 'react';
+import {
+  Button,
+  ClassroomGroup,
+  ErrorText, FieldSet,
+  FormGroup, FormHeader,
+  Input, InputGroup,
+  Label,
+  Required,
+  Select, SuccessText, Title
+} from '../common/UserStyledComponents.js';
+import styled from 'styled-components';
+
+// 모달 전용 스타일 컴포넌트
+const Overlay = styled.section`
+    position: fixed;
+    inset: 0;
+    background-color: rgba(0, 0, 0, 0.5) !important;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 50;
+    pointer-events: auto;
+    opacity: 1;
+
+    &, &:hover {
+        background-color: rgba(0, 0, 0, 0.5);
+        opacity: 1;
+    }
+`;
+
+const ModalContainer = styled.div`
+    background-color: white;
+    width: 100%;
+    max-width: 600px;
+    border-radius: 8px;
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+    opacity: 1;
+`;
+
+const ModalContent = styled.main`
+    padding: 2rem;
+    background-color: white;
+    opacity: 1;
+`;
+
+const CreateStudentModal = ({
+                              isOpen,
+                              onClose,
+                              form,
+                              errors,
+                              isIdChecked,
+                              idCheckMessage,
+                              handleInputChange,
+                              handleCheckDuplicatedId,
+                              handleSubmit
+                            }) => {
+
+  useEffect(() => {
+    if (isOpen) {
+      document.body.style.overflow = 'hidden';
+    }
+
+    return () => {
+      document.body.style.overflow = 'unset';
+    };
+  }, [isOpen]);
+
+  // 모달이 닫혀있으면 아무것도 렌더링하지 않음
+  if (!isOpen) return null;
+
+  return (
+    <Overlay onClick={onClose}>
+      <ModalContainer onClick={e => e.stopPropagation()}>
+        <ModalContent>
+          <form onSubmit={handleSubmit}>
+            <FormHeader>
+              <Title>학생 계정 생성</Title>
+            </FormHeader>
+
+            <FieldSet>
+              <FormGroup>
+                <Label>
+                  이름<Required>*</Required>
+                </Label>
+                <Input
+                  name="name"
+                  value={form.name}
+                  onChange={handleInputChange}
+                  placeholder="이름을 입력해주세요"
+                  $hasError={!!errors.name}
+                />
+                {errors.name && <ErrorText>{errors.name}</ErrorText>}
+              </FormGroup>
+
+              <FormGroup>
+                <Label>
+                  아이디<Required>*</Required>
+                </Label>
+                <InputGroup>
+                  <Input
+                    name="loginId"
+                    value={form.loginId}
+                    onChange={handleInputChange}
+                    placeholder="영문 대/소문자+숫자조합 (6~20자 이내)"
+                    $hasError={!!errors.loginId}
+                  />
+                  <Button type="button" onClick={handleCheckDuplicatedId}
+                          disabled={!form.loginId || form.loginId.length < 6 || errors.loginId}>
+                    중복 확인
+                  </Button>
+                </InputGroup>
+                {errors.loginId && <ErrorText>{errors.loginId}</ErrorText>}
+                {idCheckMessage && (
+                  <SuccessText $isSuccess={isIdChecked}>{idCheckMessage}</SuccessText>
+                )}
+              </FormGroup>
+
+              <FormGroup>
+                <Label>
+                  비밀번호<Required>*</Required>
+                </Label>
+                <Input
+                  type="password"
+                  name="password"
+                  value={form.password}
+                  onChange={handleInputChange}
+                  placeholder="영문 대/소문자+특수문자조합(9~20자 이내)"
+                  $hasError={!!errors.password}
+                />
+                {errors.password && <ErrorText>{errors.password}</ErrorText>}
+              </FormGroup>
+
+              <FormGroup>
+                <Label>
+                  비밀번호 확인<Required>*</Required>
+                </Label>
+                <Input
+                  type="password"
+                  name="passwordCheck"
+                  value={form.passwordCheck}
+                  onChange={handleInputChange}
+                  placeholder="비밀번호 확인을 위해 다시 한번 입력해주세요"
+                  $hasError={!!errors.passwordMatch}
+                />
+                {errors.passwordMatch && <ErrorText>{errors.passwordMatch}</ErrorText>}
+              </FormGroup>
+
+              <FormGroup>
+                <Label>
+                  반 정보<Required>*</Required>
+                </Label>
+                <ClassroomGroup>
+                  <Select
+                    name="grade"
+                    value={form.grade}
+                    onChange={handleInputChange}
+                    $hasError={!!errors.grade}
+                  >
+                    <option value="">학년</option>
+                    <option value="1">1학년</option>
+                    <option value="2">2학년</option>
+                    <option value="3">3학년</option>
+                  </Select>
+                  <Input
+                    name="classNumber"
+                    value={form.classNumber}
+                    onChange={handleInputChange}
+                    placeholder="반 이름"
+                    maxLength={10}
+                    $hasError={!!errors.classNumber}
+                  />
+                </ClassroomGroup>
+                {(errors.grade || errors.classNumber) && (
+                  <ErrorText>
+                    {errors.grade || errors.classNumber}
+                  </ErrorText>
+                )}
+              </FormGroup>
+
+              <FormGroup>
+                <Button type="submit" $primary style={{ width: '100%' }}>
+                  생성하기
+                </Button>
+                <Button type="button" onClick={onClose} style={{ width: '100%', marginTop: '0.5rem' }}>
+                  취소
+                </Button>
+              </FormGroup>
+            </FieldSet>
+          </form>
+        </ModalContent>
+      </ModalContainer>
+    </Overlay>
+  );
+};
+
+export default CreateStudentModal;

--- a/Frontend/edututor/src/components/classroom/StudentList.jsx
+++ b/Frontend/edututor/src/components/classroom/StudentList.jsx
@@ -1,0 +1,28 @@
+import styled from 'styled-components';
+import StudentListItem from './StudentListItem.jsx';
+
+const StudentCard = styled.div`
+    background: white;
+    border-radius: 0.5rem;
+    height: 115px;
+    box-shadow: 1px 1px 3px 3px rgba(0, 0, 0, 0.1);
+    margin-bottom: 1rem; // 카드 사이 간격
+
+    &:last-child {
+        margin-bottom: 0; // 마지막 카드는 마진 제거
+    }
+`;
+
+const StudentList = ({ students, handleDelete }) => {
+  return (
+    <>
+      {students.map(student => (
+        <StudentCard key={student.id}>
+          <StudentListItem student={student} handleDelete={handleDelete} />
+        </StudentCard>
+      ))}
+    </>
+  );
+};
+
+export default StudentList;

--- a/Frontend/edututor/src/components/classroom/StudentListItem.jsx
+++ b/Frontend/edututor/src/components/classroom/StudentListItem.jsx
@@ -34,7 +34,7 @@ const DeleteButton = styled.button`
     background: transparent;
     font-size: 1rem; // 폰트 크기 증가
     cursor: pointer;
-    transition: all 0.2s;
+    transition: all 0.5s;
 
     &:hover {
         background-color: #FEF2F2;

--- a/Frontend/edututor/src/components/classroom/StudentListItem.jsx
+++ b/Frontend/edututor/src/components/classroom/StudentListItem.jsx
@@ -1,0 +1,56 @@
+import styled from 'styled-components';
+
+const StudentItem = styled.div`
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 1.5rem 2rem; // 패딩 증가
+    height: 115px; // 높이 설정
+    box-sizing: border-box;
+`;
+
+const StudentInfo = styled.div`
+    display: flex;
+    align-items: center;
+    gap: 1.5rem; // gap 증가
+`;
+
+const Avatar = styled.div`
+    width: 3rem; // 크기 증가
+    height: 3rem; // 크기 증가
+    background-color: #f3f4f6;
+    border-radius: 9999px;
+`;
+
+const StudentName = styled.span`
+    font-size: 1.1rem; // 폰트 크기 증가
+`;
+
+const DeleteButton = styled.button`
+    padding: 0.75rem 1.5rem; // 패딩 증가
+    border-radius: 9999px;
+    border: 1px solid #FEE2E2;
+    color: #DC2626;
+    background: transparent;
+    font-size: 1rem; // 폰트 크기 증가
+    cursor: pointer;
+    transition: all 0.2s;
+
+    &:hover {
+        background-color: #FEF2F2;
+    }
+`;
+
+const StudentListItem = ({ student, handleDelete }) => {
+  return (
+    <StudentItem>
+      <StudentInfo>
+        <Avatar />
+        <StudentName>{student.fullName} ({student.loginId})</StudentName>
+      </StudentInfo>
+      <DeleteButton onClick={() => handleDelete()}>계정 삭제</DeleteButton>
+    </StudentItem>
+  );
+};
+
+export default StudentListItem;

--- a/Frontend/edututor/src/components/common/Header.jsx
+++ b/Frontend/edututor/src/components/common/Header.jsx
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import { useEffect, useState } from 'react';
 
 const HeaderContainer = styled.header`
     background: aquamarine;
@@ -28,9 +29,16 @@ const HeaderNav = styled.ul`
 const HeaderLogo = styled.div`
     height: 80px;
     background: darkblue;
+    color: white;
 `;
 
 const Header = () => {
+  const [username, setUsername] = useState('');
+
+  useEffect(() => {
+    const name = localStorage.getItem('username');
+    if (name) setUsername(name);
+  }, [username]);
   return (
     <HeaderContainer>
       <HeaderContent>
@@ -45,7 +53,7 @@ const Header = () => {
           <li>8</li>
         </HeaderNav>
         <HeaderLogo>
-          <h3>헤더</h3>
+          {username}
         </HeaderLogo>
       </HeaderContent>
     </HeaderContainer>

--- a/Frontend/edututor/src/components/common/Header.jsx
+++ b/Frontend/edututor/src/components/common/Header.jsx
@@ -36,9 +36,12 @@ const Header = () => {
   const [username, setUsername] = useState('');
 
   useEffect(() => {
-    const name = localStorage.getItem('username');
-    if (name) setUsername(name);
+    const userinfo = JSON.parse(localStorage.getItem('info'));
+    const { fullName } = userinfo;
+
+    if (fullName) setUsername(fullName);
   }, [username]);
+
   return (
     <HeaderContainer>
       <HeaderContent>

--- a/Frontend/edututor/src/components/common/UserStyledComponents.js
+++ b/Frontend/edututor/src/components/common/UserStyledComponents.js
@@ -70,7 +70,7 @@ export const Title = styled.h1`
 
 export const SubTitle = styled.h3`
     font-size: 1rem;
-    margin: 1rem;
+    margin: ${props => props.$isModal ? 0 : '1rem'};
     font-weight: bold;
     color: #333;
 `;
@@ -115,6 +115,12 @@ export const Button = styled.button`
     white-space: nowrap;
     min-width: 80px;
     font-weight: 500;
+
+    &:disabled {
+        background-color: #ccc;
+        cursor: not-allowed;
+        opacity: 0.7;
+    }
 
     ${props => {
         if (props.$primary) {

--- a/Frontend/edututor/src/components/common/UserStyledComponents.js
+++ b/Frontend/edututor/src/components/common/UserStyledComponents.js
@@ -19,7 +19,7 @@ const inputStyles = css`
     font-size: 0.875rem;
     height: 42px;
     box-sizing: border-box;
-    background-color: white;
+    background-color: ${props => props.$isFilled ? '#e8f4ff' : 'white'};
 
     &:focus {
         outline: none;
@@ -152,6 +152,7 @@ export const Button = styled.button`
         }
     }}
 `;
+
 export const Input = styled.input`
     ${inputStyles}
     width: 100%; // 부모 컨테이너의 전체 너비 사용
@@ -302,7 +303,6 @@ export const JoinButtonGroup = styled.div`
         width: auto; // width: 50% 대신 flex: 1 사용
     }
 `;
-
 
 /* 로그인 구분 화면 */
 export const LoginTypeContainer = styled.div`

--- a/Frontend/edututor/src/components/user/UserJoinForm.jsx
+++ b/Frontend/edututor/src/components/user/UserJoinForm.jsx
@@ -172,6 +172,7 @@ const UserJoinForm = ({
                   value={form.phoneMiddle}
                   onChange={getInputHandler}
                   $hasError={errors.phoneMiddle}
+                  $isFilled={form.phoneMiddle.length === 4}
                 />
                 <Divider>-</Divider>
                 <Input
@@ -180,6 +181,7 @@ const UserJoinForm = ({
                   value={form.phoneLast}
                   onChange={getInputHandler}
                   $hasError={errors.phoneLast}
+                  $isFilled={form.phoneLast.length === 4}
                 />
               </SelectGroup>
               {(errors.phoneMiddle || errors.phoneLast) && (
@@ -200,6 +202,7 @@ const UserJoinForm = ({
                   value={form.birthYear}
                   onChange={getInputHandler}
                   $hasError={errors.birthYear}
+                  $isFilled={form.birthYear.length === 4}
                 />
                 <Divider>년</Divider>
                 <DateInput
@@ -210,6 +213,7 @@ const UserJoinForm = ({
                   value={form.birthMonth}
                   onChange={getInputHandler}
                   $hasError={errors.birthMonth}
+                  $isFilled={form.birthMonth.length === 2}
                 />
                 <Divider>월</Divider>
                 <DateInput
@@ -220,6 +224,7 @@ const UserJoinForm = ({
                   value={form.birthDay}
                   onChange={getInputHandler}
                   $hasError={errors.birthDay}
+                  $isFilled={form.birthDay.length === 2}
                 />
                 <Divider>일</Divider>
               </DateGroup>

--- a/Frontend/edututor/src/components/user/UserJoinForm.jsx
+++ b/Frontend/edututor/src/components/user/UserJoinForm.jsx
@@ -332,7 +332,7 @@ const UserJoinForm = ({
 
                 {/* 반 이름 입력 */}
                 <Input name="classroomName" value={classroom.classroomName} onChange={handleCreateClassroom}
-                       placeholder="반 이름 입력 (최대 10자)"
+                       placeholder="반 이름 입력 (최대 10자, 반 빼고 ex. 갱스터반 x, 갱스터 o)"
                        maxLength={10}
                        style={{ width: '200px' }}
                 />

--- a/Frontend/edututor/src/components/user/UserJoinForm.jsx
+++ b/Frontend/edututor/src/components/user/UserJoinForm.jsx
@@ -72,7 +72,8 @@ const UserJoinForm = ({
                   placeholder="영문 대/소문자+숫자조합 (6~20자 이내)"
                   $hasError={errors.loginId}
                 />
-                <Button type="button" onClick={handleCheckDuplicatedId}>
+                <Button type="button" onClick={handleCheckDuplicatedId}
+                        disabled={!form.loginId || form.loginId.length < 6 || errors.loginId}>
                   중복 확인
                 </Button>
               </InputGroup>

--- a/Frontend/edututor/src/pages/classroom/Classroom.jsx
+++ b/Frontend/edututor/src/pages/classroom/Classroom.jsx
@@ -1,0 +1,60 @@
+import { useEffect, useState } from 'react';
+import CreateStudent from '../../components/classroom/CreateStudent.jsx';
+import StudentList from '../../components/classroom/StudentList.jsx';
+import styled from 'styled-components';
+
+const initStudent = {
+  id      : '',
+  loginId : '',
+  fullName: ''
+};
+
+const Container = styled.main`
+    min-height: 100vh;
+    padding: 2rem;
+`;
+
+const ContentWrapper = styled.article`
+    max-width: 1024px;
+    margin: 0 auto;
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+`;
+
+const Header = styled.div`
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+`;
+
+const Title = styled.h1`
+    font-size: 1.5rem;
+    font-weight: bold;
+`;
+
+const Classroom = () => {
+  const [students, setStudents] = useState([initStudent]);
+
+  useEffect(() => {
+    setStudents([{ id: 1, loginId: 'suwan', fullName: '이수완' }, { id: '2', loginId: 'duwan', fullName: '이두완' }]);
+  }, []);
+
+  const handleDelete = (studentId) => {
+    setStudents(students.filter(student => student.loginId !== studentId));
+  };
+
+  return (
+    <Container>
+      <ContentWrapper>
+        <Header>
+          <Title>구성원 관리</Title>
+          <CreateStudent />
+        </Header>
+        <StudentList students={students} handleDelete={handleDelete} />
+      </ContentWrapper>
+    </Container>
+  );
+};
+
+export default Classroom;

--- a/Frontend/edututor/src/pages/user/TeacherLogin.jsx
+++ b/Frontend/edututor/src/pages/user/TeacherLogin.jsx
@@ -67,7 +67,7 @@ const TeacherLogin = () => {
 
     try {
       const result = await login(formData);
-      localStorage.setItem('username', result);
+      localStorage.setItem('info', JSON.stringify(result));
 
       if (result) navigate('/');
     } catch (error) {

--- a/Frontend/edututor/src/pages/user/UserJoin.jsx
+++ b/Frontend/edututor/src/pages/user/UserJoin.jsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import UserJoinForm from '../../components/user/UserJoinForm.jsx';
 import SchoolSearchModal from '../../components/user/SchoolSearchModal.jsx';
-import { checkDuplicateId, join } from '../../api/user/user.js';
+import { checkDuplicateId, teacherJoin } from '../../api/user/user.js';
 import { useNavigate } from 'react-router-dom';
 
 
@@ -326,7 +326,7 @@ const UserJoin = () => {
     };
 
     try {
-      const result = await join(submitData);
+      const result = await teacherJoin(submitData);
 
       if (result.status === 204) navigate('/login');
       if (result.status === 400) alert(result.message);

--- a/Frontend/edututor/src/pages/user/UserJoin.jsx
+++ b/Frontend/edututor/src/pages/user/UserJoin.jsx
@@ -174,7 +174,6 @@ const UserJoin = () => {
 
   /* 숫자만 입력 가능한 필드 처리 */
   const handleNumberInput = (e) => {
-    console.log('이게 안되는구나');
     const { name, value } = e.target;
     const hasNonNumber = /[^0-9]/.test(value);
     const numberOnly = value.replace(/[^0-9]/g, '');

--- a/Frontend/edututor/src/pages/user/UserJoin.jsx
+++ b/Frontend/edututor/src/pages/user/UserJoin.jsx
@@ -321,7 +321,8 @@ const UserJoin = () => {
         classroomName: classroom.classroomName,
         year         : classroom.year,
         grade        : classroom.grade
-      }
+      },
+      type     : 'TE'
     };
 
     try {


### PR DESCRIPTION
## 📘요약과 목적

- 학생 추가 페이지 및 서버 구현 

## ☑️변경내용

 - 로그인 시 localStorage에 정보 저장

- CodeDetailRepository findById(String codeId) 하나로 수정

- 헤더에 로그인 됐으면 이름 변경 -> localStorage에서 가져옴

- user.js에서 선생, 학생 회원가입 메서드 분리

- UserController에서 선생, 학생 로그인 메서드 분리

-  User에서 builder 패턴 -> 정적 팩토리로 변경

- UserServiceImpl에서 회원가입 선생, 학생으로 나눔

- School에 BaseEntity 상속

- AuthUser에 classroom 추가

- UserRepository에서 @EntityGraph 추가로 classroom 가져옴

- LoginFilter에서 응답 내용 추가

- 유저 타입 추가

## 🌐전달 내용

- 아직 학생 로그인 x 

- 학생 정보수정 x

- 학생 삭제 x