### PR TITLE
footer 하단 고정 및 AUthContext 수정

### DIFF
--- a/Frontend/edututor/src/App.jsx
+++ b/Frontend/edututor/src/App.jsx
@@ -32,7 +32,6 @@ import InquiryDetail from './pages/board/InquiryDetail.jsx';
 const GlobalStyle = createGlobalStyle`
     ${reset}
     html, body {
-        height: 100%;
         font-family: 'Noto Sans KR', sans-serif;
     }
 `;

--- a/Frontend/edututor/src/Layout/MainLayout.jsx
+++ b/Frontend/edututor/src/Layout/MainLayout.jsx
@@ -1,13 +1,28 @@
 import Header from '../components/common/Header.jsx';
 import Footer from '../components/common/Footer.jsx';
+import styled from 'styled-components';
 
-const MainLayout = ( { children }) => {
+const Wrapper = styled.div`
+    position: relative;
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+`;
+
+const MainCss = styled.div`
+    flex: 1; // 남은 공간을 모두 차지하도록 설정
+    padding-bottom: 248px; // Footer 높이만큼 패딩
+`;
+
+const MainLayout = ({ children }) => {
   return (
-    <>
+    <Wrapper>
       <Header />
-      { children }
+      <MainCss>
+        {children}
+      </MainCss>
       <Footer />
-    </>
+    </Wrapper>
   );
 };
 

--- a/Frontend/edututor/src/components/common/Footer.jsx
+++ b/Frontend/edututor/src/components/common/Footer.jsx
@@ -8,8 +8,9 @@ import { Link } from 'react-router-dom';
 const FooterContainer = styled.footer`
     background: #ffffff;
     width: 100%;
-    position: relative;
-    transform: translateY(0%);
+    position: absolute;
+    height: 248px;
+    bottom: 0;
 `;
 
 // 좌측 네비게이션

--- a/Frontend/edututor/src/components/common/UserStyledComponents.js
+++ b/Frontend/edututor/src/components/common/UserStyledComponents.js
@@ -37,7 +37,6 @@ const inputStyles = css`
 
 // 레이아웃 컴포넌트
 export const Container = styled.main`
-    min-height: 100vh;
     display: flex;
     align-items: center;
     justify-content: center;

--- a/Frontend/edututor/src/pages/admin/AdminLogin.jsx
+++ b/Frontend/edututor/src/pages/admin/AdminLogin.jsx
@@ -6,7 +6,6 @@ import AdminLoginForm from '../../components/admin/AdminLoginForm.jsx';
 
 const Container = styled.div`
     display: flex;
-    min-height: 100vh;
     align-items: center;
     justify-content: center;
     background-color: #f9fafb;

--- a/Frontend/edututor/src/pages/classroom/Classroom.jsx
+++ b/Frontend/edututor/src/pages/classroom/Classroom.jsx
@@ -15,7 +15,6 @@ const initStudent = {
 };
 
 const Container = styled.main`
-    min-height: 100vh;
     padding: 2rem;
 `;
 

--- a/Frontend/edututor/src/utils/AuthContext.jsx
+++ b/Frontend/edututor/src/utils/AuthContext.jsx
@@ -6,11 +6,20 @@ import { verifyAuth } from './auth.js';
 const AuthContext = createContext();
 
 export const AuthProvider = ({ children }) => {
-  const [userInfo, setUserInfo] = useState(getUserInfo());
+  const [userInfo, setUserInfo] = useState(null);
   const [userRole, setUserRole] = useState('');
 
   const navigator = useNavigate();
   const location = useLocation();
+
+  useEffect(() => {
+    try {
+      const info = getUserInfo(true);
+      setUserInfo(info);
+    } catch (error) {
+      clearLocalStorage();
+    }
+  }, [navigator]);
 
   const verifyUserRole = async () => {
     try {


### PR DESCRIPTION
# 📘요약과 목적

- footer 하단 고정 및 AUthContext 수정

## ☑️변경내용

- MainLayout에 Wrapper css 설정

- footer 에서 transform -> bottom 0, relative -> absolute

- AuthProvider의 useEffect로 getUserInfo 호출

## 🌐전달 내용

- 없으면 없음.